### PR TITLE
fix: ConfigurationSchema OpenAPI schema to match implementation

### DIFF
--- a/docs/openapi/components/schemas/agent_types.yaml
+++ b/docs/openapi/components/schemas/agent_types.yaml
@@ -72,16 +72,36 @@ UpdateAgentTypeReq:
 ConfigurationSchema:
   type: object
   description: Schema defining validation rules and structure for agent configuration properties
-  additionalProperties:
-    $ref: "./service_types.yaml#/PropertyDefinition"
+  properties:
+    properties:
+      type: object
+      description: Property definitions keyed by property name
+      additionalProperties:
+        $ref: "./service_types.yaml#/PropertyDefinition"
+    validators:
+      type: array
+      description: Schema-level validators (e.g., exactlyOne)
+      items:
+        $ref: "./service_types.yaml#/SchemaValidatorConfig"
   example:
-    apiEndpoint:
-      type: "string"
-      label: "API Endpoint"
-      required: true
-    maxRetries:
-      type: "integer"
-      label: "Max Retries"
-      default: 3
-
+    properties:
+      apiEndpoint:
+        type: "string"
+        label: "API Endpoint"
+        required: true
+        validators:
+          - type: "pattern"
+            config:
+              pattern: "^https?://"
+      maxRetries:
+        type: "integer"
+        label: "Max Retries"
+        default: 3
+        validators:
+          - type: "min"
+            config:
+              value: 0
+          - type: "max"
+            config:
+              value: 10
 # Service Group schemas

--- a/docs/openapi/components/schemas/service_types.yaml
+++ b/docs/openapi/components/schemas/service_types.yaml
@@ -181,6 +181,25 @@ ValidatorDefinition:
       description: Configuration for the validator (structure depends on validator type)
       additionalProperties: true
 
+SchemaValidatorConfig:
+  type: object
+  required:
+    - type
+    - config
+  properties:
+    type:
+      type: string
+      enum: [exactlyOne]
+      description: Type of schema-level validator
+    config:
+      type: object
+      description: Configuration for the schema validator
+      additionalProperties: true
+  example:
+    type: "exactlyOne"
+    config:
+      properties: ["option1", "option2"]
+
 ValidationError:
   type: object
   properties:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -168,6 +168,8 @@ components:
       $ref: ./components/schemas/service_types.yaml#/ValidationError
     ValidatorDefinition:
       $ref: ./components/schemas/service_types.yaml#/ValidatorDefinition
+    SchemaValidatorConfig:
+      $ref: ./components/schemas/service_types.yaml#/SchemaValidatorConfig
     properties.UUID:
       $ref: ./components/schemas/common.yaml#/properties.UUID
 


### PR DESCRIPTION
- Restructure ConfigurationSchema to include properties and validators fields
- Add SchemaValidatorConfig schema definition for schema-level validators