### PR TITLE
fix: participant repository authorization filter

### DIFF
--- a/pkg/database/gorm_repo_base.go
+++ b/pkg/database/gorm_repo_base.go
@@ -143,6 +143,13 @@ func participantAuthzFilterApplier(s *auth.IdentityScope, q *gorm.DB) *gorm.DB {
 	return q
 }
 
+func participantSelfAuthzFilterApplier(s *auth.IdentityScope, q *gorm.DB) *gorm.DB {
+	if s.ParticipantID != nil {
+		return q.Where("id = ?", s.ParticipantID)
+	}
+	return q
+}
+
 func providerConsumerAgentAuthzFilterApplier(s *auth.IdentityScope, q *gorm.DB) *gorm.DB {
 	if s.ParticipantID != nil {
 		return q.Where("consumer_id = ? OR provider_id = ?", s.ParticipantID, s.ParticipantID)

--- a/pkg/database/gorm_repo_participant.go
+++ b/pkg/database/gorm_repo_participant.go
@@ -30,7 +30,7 @@ func NewParticipantRepository(db *gorm.DB) *GormParticipantRepository {
 			db,
 			applyParticipantFilter,
 			applyParticipantSort,
-			participantAuthzFilterApplier,
+			participantSelfAuthzFilterApplier,
 			[]string{}, // Find preload paths - no specific preloads required for participants
 			[]string{}, // List preload paths - no specific preloads required for participants
 		),

--- a/pkg/database/gorm_repo_participant_test.go
+++ b/pkg/database/gorm_repo_participant_test.go
@@ -1,0 +1,161 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fulcrumproject/core/pkg/auth"
+	"github.com/fulcrumproject/core/pkg/domain"
+	"github.com/fulcrumproject/core/pkg/properties"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParticipantRepository(t *testing.T) {
+	tdb := NewTestDB(t)
+	defer tdb.Cleanup(t)
+	// Create repository
+	repo := NewParticipantRepository(tdb.DB)
+	t.Run("create", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			ctx := context.Background()
+
+			participant := createTestParticipant(t, domain.ParticipantEnabled)
+
+			err := repo.Create(ctx, participant)
+
+			require.NoError(t, err)
+			
+			found, err := repo.Get(ctx, participant.ID)
+
+			require.NoError(t, err)
+			assert.Equal(t, participant.ID, found.ID)
+		})
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			ctx := context.Background()
+
+			participant := createTestParticipant(t, domain.ParticipantEnabled)
+
+			err := repo.Create(ctx, participant)
+
+			require.NoError(t, err)
+
+			found, err := repo.Get(ctx, participant.ID)
+			
+			require.NoError(t, err)
+
+			assert.Equal(t, participant.ID, found.ID)
+			assert.Equal(t, participant.Name, found.Name)
+		})
+
+		t.Run("not found", func(t *testing.T) {
+			ctx := context.Background()
+
+			found, err := repo.Get(ctx, properties.NewUUID())
+
+			assert.Nil(t, found)
+			assert.ErrorAs(t, err, &domain.NotFoundError{})
+		})
+	})
+
+	t.Run("List", func(t *testing.T) {
+		t.Run("success - list all", func(t *testing.T) {
+			ctx := context.Background()
+
+			// Setup
+			participant1 := createTestParticipant(t, domain.ParticipantEnabled)
+			require.NoError(t, repo.Create(ctx, participant1))
+			participant2 := createTestParticipant(t, domain.ParticipantEnabled)
+			require.NoError(t, repo.Create(ctx, participant2))
+
+			page := &domain.PageReq{
+				Page:     1,
+				PageSize: 10,
+			}
+
+			// Execute
+			result, err := repo.List(ctx, &auth.IdentityScope{}, page)
+
+			// Assert
+			require.NoError(t, err)
+			assert.GreaterOrEqual(t, len(result.Items), 2)
+		})
+		t.Run("success - list with participant scope filter", func(t *testing.T) {
+			ctx := context.Background()
+
+			// Setup - Create two participants
+			participant1 := createTestParticipant(t, domain.ParticipantEnabled)
+			require.NoError(t, repo.Create(ctx, participant1))
+			participant2 := createTestParticipant(t, domain.ParticipantEnabled)
+			require.NoError(t, repo.Create(ctx, participant2))
+
+			page := &domain.PageReq{
+				Page:     1,
+				PageSize: 10,
+			}
+
+			// Execute with participant1 scope
+			scope := &auth.IdentityScope{
+				ParticipantID: &participant1.ID,
+			}
+			result, err := repo.List(ctx, scope, page)
+
+			// Assert - should only return participant1
+			require.NoError(t, err)
+			require.Len(t, result.Items, 1)
+			assert.Equal(t, participant1.ID, result.Items[0].ID)
+		})
+	})
+	t.Run("Save", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			ctx := context.Background()
+
+			// Setup
+			participant := createTestParticipant(t, domain.ParticipantEnabled)
+			require.NoError(t, repo.Create(ctx, participant))
+
+			// Read
+			participant, err := repo.Get(ctx, participant.ID)
+			require.NoError(t, err)
+
+			// Update participant
+			participant.Name = "Updated Participant"
+			participant.Status = domain.ParticipantDisabled
+
+			// Execute
+			err = repo.Save(ctx, participant)
+
+			// Assert
+			require.NoError(t, err)
+
+			// Verify in database
+			updated, err := repo.Get(ctx, participant.ID)
+			require.NoError(t, err)
+			assert.Equal(t, "Updated Participant", updated.Name)
+			assert.Equal(t, domain.ParticipantDisabled, updated.Status)
+		})
+	})
+	t.Run("Delete", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			ctx := context.Background()
+
+			// Setup
+			participant := createTestParticipant(t, domain.ParticipantEnabled)
+			require.NoError(t, repo.Create(ctx, participant))
+
+			// Execute
+			err := repo.Delete(ctx, participant.ID)
+
+			// Assert
+			require.NoError(t, err)
+
+			// Verify deletion
+			found, err := repo.Get(ctx, participant.ID)
+			assert.Nil(t, found)
+			assert.ErrorAs(t, err, &domain.NotFoundError{})
+		})
+	})
+}


### PR DESCRIPTION
- Add participantSelfAuthzFilterApplier to filter participants by their own ID
- Update participant repository to use the new self-filter instead of provider filter
- Add participant repository tests