### PR TITLE
fix: update service pool endpoints to use Services tag

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -16,7 +16,7 @@ tags:
   - name: Agents
     description: Agent and agent type management
   - name: Services
-    description: Service, service type, and service group management
+    description: Service, service type, service group management and service pools
   - name: Jobs
     description: Job queue and processing
   - name: Metrics

--- a/docs/openapi/paths/service-pool-sets.yaml
+++ b/docs/openapi/paths/service-pool-sets.yaml
@@ -62,7 +62,7 @@ post:
   operationId: servicePoolSetsCreate
   summary: Create a service pool set
   tags:
-    - Service Pools
+    - Services
   description: Creates a new service pool set
   x-auth-permissions:
     - role: admin

--- a/docs/openapi/paths/service-pool-sets@{id}.yaml
+++ b/docs/openapi/paths/service-pool-sets@{id}.yaml
@@ -32,7 +32,7 @@ patch:
   operationId: servicePoolSetsUpdate
   summary: Update a service pool set
   tags:
-    - Service Pools
+    - Services
   description: Updates an existing service pool set
   x-auth-permissions:
     - role: admin
@@ -70,7 +70,7 @@ delete:
   operationId: servicePoolSetsDelete
   summary: Delete a service pool set
   tags:
-    - Service Pools
+    - Services
   description: Deletes an existing service pool set
   x-auth-permissions:
     - role: admin

--- a/docs/openapi/paths/service-pool-values.yaml
+++ b/docs/openapi/paths/service-pool-values.yaml
@@ -64,7 +64,7 @@ post:
   operationId: servicePoolValuesCreate
   summary: Create a service pool value
   tags:
-    - Service Pools
+    - Services
   description: Creates a new service pool value (for list generators only)
   x-auth-permissions:
     - role: admin

--- a/docs/openapi/paths/service-pool-values@{id}.yaml
+++ b/docs/openapi/paths/service-pool-values@{id}.yaml
@@ -34,7 +34,7 @@ delete:
   operationId: servicePoolValuesDelete
   summary: Delete a service pool value
   tags:
-    - Service Pools
+    - Services
   description: Deletes an existing service pool value (only if not allocated)
   x-auth-permissions:
     - role: admin

--- a/docs/openapi/paths/service-pools.yaml
+++ b/docs/openapi/paths/service-pools.yaml
@@ -72,7 +72,7 @@ post:
   operationId: servicePoolsCreate
   summary: Create a service pool
   tags:
-    - Service Pools
+    - Services
   description: Creates a new service pool
   x-auth-permissions:
     - role: admin

--- a/docs/openapi/paths/service-pools@{id}.yaml
+++ b/docs/openapi/paths/service-pools@{id}.yaml
@@ -34,7 +34,7 @@ patch:
   operationId: servicePoolsUpdate
   summary: Update a service pool
   tags:
-    - Service Pools
+    - Services
   description: Updates an existing service pool
   x-auth-permissions:
     - role: admin
@@ -72,7 +72,7 @@ delete:
   operationId: servicePoolsDelete
   summary: Delete a service pool
   tags:
-    - Service Pools
+    - Services
   description: Deletes an existing service pool
   x-auth-permissions:
     - role: admin


### PR DESCRIPTION
- Change all service pool endpoint tags from 'Service Pools' to 'Services'
- Update Services tag description to include service pools