### PR TITLE
Add validation error response schema and update service endpoints

### DIFF
--- a/docs/openapi/components/responses.yaml
+++ b/docs/openapi/components/responses.yaml
@@ -4,6 +4,20 @@ BadRequest:
     application/json:
       schema:
         $ref: "./schemas/common.yaml#/ErrorRes"
+ValidationErrors:
+  description: Validation errors - request contains invalid or missing required fields
+  content:
+    application/json:
+      schema:
+        $ref: "./schemas/common.yaml#/ValidationErrRes"
+      example:
+        status: "Validation failed"
+        valid: false
+        errors:
+          - path: "cpu"
+            message: "cpu: value must be one of: [1, 2, 4, 8, 16, 32]"
+          - path: "memory"
+            message: "memory: property is required"
 Unauthorized:
   description: Unauthorized
   content:
@@ -22,4 +36,3 @@ InternalServerError:
     application/json:
       schema:
         $ref: "./schemas/common.yaml#/ErrorRes"
-

--- a/docs/openapi/components/schemas/common.yaml
+++ b/docs/openapi/components/schemas/common.yaml
@@ -43,3 +43,40 @@ PageRes:
     hasPrev:
       type: boolean
       description: Whether there is a previous page
+
+ValidationErrorDetail:
+  type: object
+  required:
+    - path
+    - message
+  properties:
+    path:
+      type: string
+      description: The property path that failed validation
+      example: "cpu"
+    message:
+      type: string
+      description: The validation error message
+      example: "cpu: value must be one of: [1, 2, 4, 8, 16, 32]"
+
+ValidationErrRes:
+  type: object
+  required:
+    - status
+    - valid
+    - errors
+  properties:
+    status:
+      type: string
+      description: User-level status message
+      example: "Validation failed"
+    valid:
+      type: boolean
+      description: Whether the validation passed
+      example: false
+    errors:
+      type: array
+      items:
+        $ref: "#/ValidationErrorDetail"
+      description: Array of validation errors with detailed information about each failure
+      minItems: 1

--- a/docs/openapi/paths/services.yaml
+++ b/docs/openapi/paths/services.yaml
@@ -87,8 +87,4 @@ post:
           schema:
             $ref: "../components/schemas/services.yaml#/ServiceRes"
     "400":
-      description: Invalid request or validation failed
-      content:
-        application/json:
-          schema:
-            $ref: "../components/schemas/common.yaml#/ErrorRes"
+      $ref: "../components/responses.yaml#/ValidationErrors"

--- a/docs/openapi/paths/services@{id}.yaml
+++ b/docs/openapi/paths/services@{id}.yaml
@@ -78,11 +78,7 @@ patch:
           schema:
             $ref: "../components/schemas/services.yaml#/ServiceRes"
     "400":
-      description: Invalid request or validation failed
-      content:
-        application/json:
-          schema:
-            $ref: "../components/schemas/common.yaml#/ErrorRes"
+      $ref: "../components/responses.yaml#/ValidationErrors"
     "404":
       description: Service not found
       content:


### PR DESCRIPTION
- Add ValidationErrors response definition with detailed error structure
- Add ValidationErrorDetail and ValidationErrRes schemas to common.yaml
- Update POST /services and PATCH /services/{id} to use ValidationErrors response
- Provides structured validation error responses with path and message details