### PR TITLE
fix: enforce service pool type uniqueness per provider

### DIFF
--- a/pkg/database/gorm_repo_service_pool.go
+++ b/pkg/database/gorm_repo_service_pool.go
@@ -95,6 +95,28 @@ func (r *GormServicePoolRepository) FindByPoolSetAndType(
 	return &entity, nil
 }
 
+// FindByProviderAndType retrieves a service pool by provider and type, joining
+// through service_pool_sets since ProviderID is not a column on service_pools.
+func (r *GormServicePoolRepository) FindByProviderAndType(
+	ctx context.Context,
+	providerID properties.UUID,
+	poolType string,
+) (*domain.ServicePool, error) {
+	var entity domain.ServicePool
+	result := r.db.WithContext(ctx).
+		Joins("JOIN service_pool_sets ON service_pool_sets.id = service_pools.service_pool_set_id").
+		Where("service_pool_sets.provider_id = ? AND service_pools.type = ?", providerID, poolType).
+		First(&entity)
+
+	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			return nil, domain.NotFoundError{Err: result.Error}
+		}
+		return nil, result.Error
+	}
+	return &entity, nil
+}
+
 // Update updates an existing service pool
 func (r *GormServicePoolRepository) Update(ctx context.Context, pool *domain.ServicePool) error {
 	return r.Save(ctx, pool)

--- a/pkg/database/gorm_repo_service_pool_test.go
+++ b/pkg/database/gorm_repo_service_pool_test.go
@@ -314,6 +314,53 @@ func TestServicePoolRepository(t *testing.T) {
 		})
 	})
 
+	t.Run("FindByProviderAndType", func(t *testing.T) {
+		t.Run("success - same provider different pool set", func(t *testing.T) {
+			ctx := context.Background()
+
+			poolType := fmt.Sprintf("unique-type-%s", uuid.New().String())
+
+			pool := createTestServicePool(t, poolSet.ID)
+			pool.Type = poolType
+			require.NoError(t, repo.Create(ctx, pool))
+
+			otherPoolSet := createTestServicePoolSet(t, participant.ID)
+			require.NoError(t, poolSetRepo.Create(ctx, otherPoolSet))
+
+			found, err := repo.FindByProviderAndType(ctx, participant.ID, poolType)
+
+			require.NoError(t, err)
+			assert.Equal(t, pool.ID, found.ID)
+		})
+
+		t.Run("not found - different provider", func(t *testing.T) {
+			ctx := context.Background()
+
+			poolType := fmt.Sprintf("unique-type-%s", uuid.New().String())
+
+			pool := createTestServicePool(t, poolSet.ID)
+			pool.Type = poolType
+			require.NoError(t, repo.Create(ctx, pool))
+
+			otherProvider := createTestParticipant(t, domain.ParticipantEnabled)
+			require.NoError(t, participantRepo.Create(ctx, otherProvider))
+
+			found, err := repo.FindByProviderAndType(ctx, otherProvider.ID, poolType)
+
+			assert.Nil(t, found)
+			assert.ErrorAs(t, err, &domain.NotFoundError{})
+		})
+
+		t.Run("not found - unknown type", func(t *testing.T) {
+			ctx := context.Background()
+
+			found, err := repo.FindByProviderAndType(ctx, participant.ID, "nonexistent-type")
+
+			assert.Nil(t, found)
+			assert.ErrorAs(t, err, &domain.NotFoundError{})
+		})
+	})
+
 	t.Run("Update", func(t *testing.T) {
 		t.Run("success", func(t *testing.T) {
 			ctx := context.Background()

--- a/pkg/domain/mocks.go
+++ b/pkg/domain/mocks.go
@@ -22877,6 +22877,80 @@ func (_c *MockServicePoolRepository_FindByPoolSetAndType_Call) RunAndReturn(run 
 	return _c
 }
 
+// FindByProviderAndType provides a mock function for the type MockServicePoolRepository
+func (_mock *MockServicePoolRepository) FindByProviderAndType(ctx context.Context, providerID properties.UUID, poolType string) (*ServicePool, error) {
+	ret := _mock.Called(ctx, providerID, poolType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindByProviderAndType")
+	}
+
+	var r0 *ServicePool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, properties.UUID, string) (*ServicePool, error)); ok {
+		return returnFunc(ctx, providerID, poolType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, properties.UUID, string) *ServicePool); ok {
+		r0 = returnFunc(ctx, providerID, poolType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ServicePool)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, properties.UUID, string) error); ok {
+		r1 = returnFunc(ctx, providerID, poolType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockServicePoolRepository_FindByProviderAndType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindByProviderAndType'
+type MockServicePoolRepository_FindByProviderAndType_Call struct {
+	*mock.Call
+}
+
+// FindByProviderAndType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - providerID properties.UUID
+//   - poolType string
+func (_e *MockServicePoolRepository_Expecter) FindByProviderAndType(ctx interface{}, providerID interface{}, poolType interface{}) *MockServicePoolRepository_FindByProviderAndType_Call {
+	return &MockServicePoolRepository_FindByProviderAndType_Call{Call: _e.mock.On("FindByProviderAndType", ctx, providerID, poolType)}
+}
+
+func (_c *MockServicePoolRepository_FindByProviderAndType_Call) Run(run func(ctx context.Context, providerID properties.UUID, poolType string)) *MockServicePoolRepository_FindByProviderAndType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 properties.UUID
+		if args[1] != nil {
+			arg1 = args[1].(properties.UUID)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockServicePoolRepository_FindByProviderAndType_Call) Return(servicePool *ServicePool, err error) *MockServicePoolRepository_FindByProviderAndType_Call {
+	_c.Call.Return(servicePool, err)
+	return _c
+}
+
+func (_c *MockServicePoolRepository_FindByProviderAndType_Call) RunAndReturn(run func(ctx context.Context, providerID properties.UUID, poolType string) (*ServicePool, error)) *MockServicePoolRepository_FindByProviderAndType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Get provides a mock function for the type MockServicePoolRepository
 func (_mock *MockServicePoolRepository) Get(ctx context.Context, id properties.UUID) (*ServicePool, error) {
 	ret := _mock.Called(ctx, id)
@@ -23435,6 +23509,80 @@ func (_c *MockServicePoolQuerier_FindByPoolSetAndType_Call) Return(servicePool *
 }
 
 func (_c *MockServicePoolQuerier_FindByPoolSetAndType_Call) RunAndReturn(run func(ctx context.Context, poolSetID properties.UUID, poolType string) (*ServicePool, error)) *MockServicePoolQuerier_FindByPoolSetAndType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindByProviderAndType provides a mock function for the type MockServicePoolQuerier
+func (_mock *MockServicePoolQuerier) FindByProviderAndType(ctx context.Context, providerID properties.UUID, poolType string) (*ServicePool, error) {
+	ret := _mock.Called(ctx, providerID, poolType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindByProviderAndType")
+	}
+
+	var r0 *ServicePool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, properties.UUID, string) (*ServicePool, error)); ok {
+		return returnFunc(ctx, providerID, poolType)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, properties.UUID, string) *ServicePool); ok {
+		r0 = returnFunc(ctx, providerID, poolType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*ServicePool)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, properties.UUID, string) error); ok {
+		r1 = returnFunc(ctx, providerID, poolType)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockServicePoolQuerier_FindByProviderAndType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindByProviderAndType'
+type MockServicePoolQuerier_FindByProviderAndType_Call struct {
+	*mock.Call
+}
+
+// FindByProviderAndType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - providerID properties.UUID
+//   - poolType string
+func (_e *MockServicePoolQuerier_Expecter) FindByProviderAndType(ctx interface{}, providerID interface{}, poolType interface{}) *MockServicePoolQuerier_FindByProviderAndType_Call {
+	return &MockServicePoolQuerier_FindByProviderAndType_Call{Call: _e.mock.On("FindByProviderAndType", ctx, providerID, poolType)}
+}
+
+func (_c *MockServicePoolQuerier_FindByProviderAndType_Call) Run(run func(ctx context.Context, providerID properties.UUID, poolType string)) *MockServicePoolQuerier_FindByProviderAndType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 properties.UUID
+		if args[1] != nil {
+			arg1 = args[1].(properties.UUID)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockServicePoolQuerier_FindByProviderAndType_Call) Return(servicePool *ServicePool, err error) *MockServicePoolQuerier_FindByProviderAndType_Call {
+	_c.Call.Return(servicePool, err)
+	return _c
+}
+
+func (_c *MockServicePoolQuerier_FindByProviderAndType_Call) RunAndReturn(run func(ctx context.Context, providerID properties.UUID, poolType string) (*ServicePool, error)) *MockServicePoolQuerier_FindByProviderAndType_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/domain/service_pool.go
+++ b/pkg/domain/service_pool.go
@@ -3,6 +3,7 @@ package domain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -128,6 +129,7 @@ type ServicePoolQuerier interface {
 
 	ListByPoolSet(ctx context.Context, poolSetID properties.UUID) ([]*ServicePool, error)
 	FindByPoolSetAndType(ctx context.Context, poolSetID properties.UUID, poolType string) (*ServicePool, error)
+	FindByProviderAndType(ctx context.Context, providerID properties.UUID, poolType string) (*ServicePool, error)
 }
 
 // ServicePoolCommander handles complex ServicePool operations
@@ -155,18 +157,32 @@ func (c *servicePoolCommander) Create(
 	var pool *ServicePool
 	err := c.store.Atomic(ctx, func(store Store) error {
 		// Validate that the pool set exists
-		exists, err := store.ServicePoolSetRepo().Exists(ctx, params.ServicePoolSetID)
+		poolSet, err := store.ServicePoolSetRepo().Get(ctx, params.ServicePoolSetID)
 		if err != nil {
+			var notFound NotFoundError
+			if errors.As(err, &notFound) {
+				return NewNotFoundErrorf("service pool set with id %s not found", params.ServicePoolSetID)
+			}
 			return err
-		}
-		if !exists {
-			return NewNotFoundErrorf("service pool set with id %s not found", params.ServicePoolSetID)
 		}
 
 		// Create the pool
 		pool = NewServicePool(params)
 		if err := pool.Validate(); err != nil {
 			return err
+		}
+
+		// Type must be unique per provider — the pool resolver matches by type
+		// and will silently pick one of the duplicates; if that one is empty
+		// allocation fails with a misleading "no available pool values".
+		existing, err := store.ServicePoolRepo().FindByProviderAndType(ctx, poolSet.ProviderID, pool.Type)
+		if err != nil {
+			var notFound NotFoundError
+			if !errors.As(err, &notFound) {
+				return err
+			}
+		} else if existing != nil {
+			return NewInvalidInputErrorf("service pool with type %q already exists for this provider", pool.Type)
 		}
 
 		// Save to database

--- a/test/rest/service_pool.http
+++ b/test/rest/service_pool.http
@@ -1,0 +1,172 @@
+### Service Pool Operations
+### This file tests CRUD on service pools and the per-provider
+### (providerId, type) uniqueness rule.
+
+### Variables
+@baseUrl = http://localhost:3000/api/v1
+@adminToken = change-me
+
+### Get all service pools
+GET {{baseUrl}}/service-pools
+Authorization: Bearer {{adminToken}}
+
+### Get all service pools with filter by name
+GET {{baseUrl}}/service-pools?name=test
+Authorization: Bearer {{adminToken}}
+
+### Get all service pools with filter by type
+GET {{baseUrl}}/service-pools?type=public_ip
+Authorization: Bearer {{adminToken}}
+
+### Get all service pools with filter by generatorType
+GET {{baseUrl}}/service-pools?generatorType=list
+Authorization: Bearer {{adminToken}}
+
+
+### Create Provider A
+# @name createProviderA
+POST {{baseUrl}}/participants
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Test Provider A {{$guid}}",
+    "status": "Enabled",
+    "attributes": {
+        "type": ["test"]
+    }
+}
+
+### Create Pool Set A1 under Provider A
+# @name createPoolSetA1
+POST {{baseUrl}}/service-pool-sets
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Pool Set A1 {{$guid}}",
+    "providerId": "{{createProviderA.response.body.id}}"
+}
+
+### Create Service Pool in Set A1
+# @name createPoolA1
+POST {{baseUrl}}/service-pools
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Public IP Pool",
+    "type": "public_ip",
+    "propertyType": "string",
+    "generatorType": "list",
+    "servicePoolSetId": "{{createPoolSetA1.response.body.id}}"
+}
+
+@servicePoolId = {{createPoolA1.response.body.$.id}}
+
+### Get the pool by id
+GET {{baseUrl}}/service-pools/{{servicePoolId}}
+Authorization: Bearer {{adminToken}}
+
+### Update the pool
+PATCH {{baseUrl}}/service-pools/{{servicePoolId}}
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Public IP Pool (updated)"
+}
+
+###
+### Duplicate-type checks
+###
+### Before the (providerId, type) constraint the next two requests would
+### return 201 and later cause `no available pool values` at service
+### allocation time. With the constraint they return 400 InvalidInput.
+
+### Duplicate in the SAME pool set — should fail (400)
+POST {{baseUrl}}/service-pools
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Public IP Pool duplicate",
+    "type": "public_ip",
+    "propertyType": "string",
+    "generatorType": "list",
+    "servicePoolSetId": "{{createPoolSetA1.response.body.id}}"
+}
+
+### Create a second pool set under the SAME provider
+# @name createPoolSetA2
+POST {{baseUrl}}/service-pool-sets
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Pool Set A2 {{$guid}}",
+    "providerId": "{{createProviderA.response.body.id}}"
+}
+
+### Duplicate type in a DIFFERENT pool set of the same provider — should fail (400)
+POST {{baseUrl}}/service-pools
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Public IP Pool cross-set",
+    "type": "public_ip",
+    "propertyType": "string",
+    "generatorType": "list",
+    "servicePoolSetId": "{{createPoolSetA2.response.body.id}}"
+}
+
+###
+### Cross-provider reuse is allowed
+###
+
+### Create Provider B
+# @name createProviderB
+POST {{baseUrl}}/participants
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Test Provider B {{$guid}}",
+    "status": "Enabled",
+    "attributes": {
+        "type": ["test"]
+    }
+}
+
+### Create Pool Set B1 under Provider B
+# @name createPoolSetB1
+POST {{baseUrl}}/service-pool-sets
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Pool Set B1 {{$guid}}",
+    "providerId": "{{createProviderB.response.body.id}}"
+}
+
+### Same type under a DIFFERENT provider — should succeed (201)
+POST {{baseUrl}}/service-pools
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+    "name": "Public IP Pool (provider B)",
+    "type": "public_ip",
+    "propertyType": "string",
+    "generatorType": "list",
+    "servicePoolSetId": "{{createPoolSetB1.response.body.id}}"
+}
+
+###
+### Cleanup
+###
+
+### Delete the first pool
+DELETE {{baseUrl}}/service-pools/{{servicePoolId}}
+Authorization: Bearer {{adminToken}}


### PR DESCRIPTION
Previously duplicate (providerId, type) pools could be created across pool sets, causing the pool resolver to silently pick one and fail with "no available pool values" at allocation time.