### PR TITLE
fix: now agent type joins tables follow guard pattern for service typ…

### DIFF
--- a/pkg/database/gorm_repo_agent_type.go
+++ b/pkg/database/gorm_repo_agent_type.go
@@ -65,6 +65,33 @@ func (r *GormAgentTypeRepository) Save(ctx context.Context, agentType *domain.Ag
 	return nil
 }
 
+// Delete overrides the base Delete to clear the many-to-many join rows before
+// removing the agent type. The join tables have no ON DELETE CASCADE, so without
+// this the rows orphan and inflate CountBy* on the referenced types.
+func (r *GormAgentTypeRepository) Delete(ctx context.Context, id properties.UUID) error {
+	agentType := &domain.AgentType{BaseEntity: domain.BaseEntity{ID: id}}
+	if err := r.db.WithContext(ctx).Model(agentType).Association("ServiceTypes").Clear(); err != nil {
+		return err
+	}
+	if err := r.db.WithContext(ctx).Model(agentType).Association("InfrastructureTypes").Clear(); err != nil {
+		return err
+	}
+	return r.db.WithContext(ctx).Delete(agentType).Error
+}
+
+func (r *GormAgentTypeRepository) CountByServiceType(ctx context.Context, serviceTypeID properties.UUID) (int64, error) {
+	var count int64
+	result := r.db.WithContext(ctx).
+		Model(&domain.AgentType{}).
+		Joins("JOIN agent_type_service_types ON agent_types.id = agent_type_service_types.agent_type_id").
+		Where("agent_type_service_types.service_type_id = ?", serviceTypeID).
+		Count(&count)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return count, nil
+}
+
 func (r *GormAgentTypeRepository) CountByInfrastructureType(ctx context.Context, infrastructureTypeID properties.UUID) (int64, error) {
 	var count int64
 	result := r.db.WithContext(ctx).

--- a/pkg/database/gorm_repo_agent_type_test.go
+++ b/pkg/database/gorm_repo_agent_type_test.go
@@ -338,6 +338,61 @@ func TestAgentTypeRepository(t *testing.T) {
 		assert.Equal(t, int64(1), n)
 	})
 
+	t.Run("CountByServiceType", func(t *testing.T) {
+		ctx := context.Background()
+
+		st := createTestServiceType(t)
+		require.NoError(t, serviceTypeRepo.Create(ctx, st))
+		other := createTestServiceType(t)
+		require.NoError(t, serviceTypeRepo.Create(ctx, other))
+
+		// 2 AgentTypes reference `st`; 1 references `other`
+		for i := 0; i < 2; i++ {
+			at := createTestAgentType(t)
+			at.ServiceTypes = []domain.ServiceType{*st}
+			require.NoError(t, repo.Create(ctx, at))
+		}
+		atOther := createTestAgentType(t)
+		atOther.ServiceTypes = []domain.ServiceType{*other}
+		require.NoError(t, repo.Create(ctx, atOther))
+
+		n, err := repo.CountByServiceType(ctx, st.ID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), n)
+
+		n, err = repo.CountByServiceType(ctx, other.ID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), n)
+	})
+
+	t.Run("Delete removes join rows", func(t *testing.T) {
+		ctx := context.Background()
+		infraTypeRepo := NewInfrastructureTypeRepository(tdb.DB)
+
+		st := createTestServiceType(t)
+		require.NoError(t, serviceTypeRepo.Create(ctx, st))
+		it := createTestInfrastructureType(t)
+		require.NoError(t, infraTypeRepo.Create(ctx, it))
+
+		at := createTestAgentType(t)
+		at.ServiceTypes = []domain.ServiceType{*st}
+		at.InfrastructureTypes = []domain.InfrastructureType{*it}
+		require.NoError(t, repo.Create(ctx, at))
+
+		require.NoError(t, repo.Delete(ctx, at.ID))
+
+		// Join rows must be physically gone, not just hidden behind the preload JOIN.
+		// Use a fresh session for the raw Table() query so it does not mutate the
+		// shared tdb.DB statement and leak the join table name into later creates.
+		var stRows, itRows int64
+		require.NoError(t, tdb.DB.WithContext(ctx).Table("agent_type_service_types").
+			Where("agent_type_id = ?", at.ID).Count(&stRows).Error)
+		require.NoError(t, tdb.DB.WithContext(ctx).Table("agent_type_infrastructure_types").
+			Where("agent_type_id = ?", at.ID).Count(&itRows).Error)
+		assert.Zero(t, stRows, "service type join rows must be removed when the agent type is deleted")
+		assert.Zero(t, itRows, "infrastructure type join rows must be removed when the agent type is deleted")
+	})
+
 	t.Run("AuthScope", func(t *testing.T) {
 		t.Run("success - returns empty auth scope", func(t *testing.T) {
 			ctx := context.Background()

--- a/pkg/domain/agent_type.go
+++ b/pkg/domain/agent_type.go
@@ -311,4 +311,7 @@ type AgentTypeQuerier interface {
 
 	// CountByInfrastructureType returns the number of agent types bound to a specific infrastructure type
 	CountByInfrastructureType(ctx context.Context, infrastructureTypeID properties.UUID) (int64, error)
+
+	// CountByServiceType returns the number of agent types bound to a specific service type
+	CountByServiceType(ctx context.Context, serviceTypeID properties.UUID) (int64, error)
 }

--- a/pkg/domain/mocks.go
+++ b/pkg/domain/mocks.go
@@ -2250,6 +2250,72 @@ func (_c *MockAgentTypeRepository_CountByInfrastructureType_Call) RunAndReturn(r
 	return _c
 }
 
+// CountByServiceType provides a mock function for the type MockAgentTypeRepository
+func (_mock *MockAgentTypeRepository) CountByServiceType(ctx context.Context, serviceTypeID properties.UUID) (int64, error) {
+	ret := _mock.Called(ctx, serviceTypeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountByServiceType")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, properties.UUID) (int64, error)); ok {
+		return returnFunc(ctx, serviceTypeID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, properties.UUID) int64); ok {
+		r0 = returnFunc(ctx, serviceTypeID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, properties.UUID) error); ok {
+		r1 = returnFunc(ctx, serviceTypeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockAgentTypeRepository_CountByServiceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountByServiceType'
+type MockAgentTypeRepository_CountByServiceType_Call struct {
+	*mock.Call
+}
+
+// CountByServiceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - serviceTypeID properties.UUID
+func (_e *MockAgentTypeRepository_Expecter) CountByServiceType(ctx interface{}, serviceTypeID interface{}) *MockAgentTypeRepository_CountByServiceType_Call {
+	return &MockAgentTypeRepository_CountByServiceType_Call{Call: _e.mock.On("CountByServiceType", ctx, serviceTypeID)}
+}
+
+func (_c *MockAgentTypeRepository_CountByServiceType_Call) Run(run func(ctx context.Context, serviceTypeID properties.UUID)) *MockAgentTypeRepository_CountByServiceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 properties.UUID
+		if args[1] != nil {
+			arg1 = args[1].(properties.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAgentTypeRepository_CountByServiceType_Call) Return(n int64, err error) *MockAgentTypeRepository_CountByServiceType_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockAgentTypeRepository_CountByServiceType_Call) RunAndReturn(run func(ctx context.Context, serviceTypeID properties.UUID) (int64, error)) *MockAgentTypeRepository_CountByServiceType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Create provides a mock function for the type MockAgentTypeRepository
 func (_mock *MockAgentTypeRepository) Create(ctx context.Context, entity *AgentType) error {
 	ret := _mock.Called(ctx, entity)
@@ -2846,6 +2912,72 @@ func (_c *MockAgentTypeQuerier_CountByInfrastructureType_Call) Return(n int64, e
 }
 
 func (_c *MockAgentTypeQuerier_CountByInfrastructureType_Call) RunAndReturn(run func(ctx context.Context, infrastructureTypeID properties.UUID) (int64, error)) *MockAgentTypeQuerier_CountByInfrastructureType_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CountByServiceType provides a mock function for the type MockAgentTypeQuerier
+func (_mock *MockAgentTypeQuerier) CountByServiceType(ctx context.Context, serviceTypeID properties.UUID) (int64, error) {
+	ret := _mock.Called(ctx, serviceTypeID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountByServiceType")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, properties.UUID) (int64, error)); ok {
+		return returnFunc(ctx, serviceTypeID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, properties.UUID) int64); ok {
+		r0 = returnFunc(ctx, serviceTypeID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, properties.UUID) error); ok {
+		r1 = returnFunc(ctx, serviceTypeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockAgentTypeQuerier_CountByServiceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountByServiceType'
+type MockAgentTypeQuerier_CountByServiceType_Call struct {
+	*mock.Call
+}
+
+// CountByServiceType is a helper method to define mock.On call
+//   - ctx context.Context
+//   - serviceTypeID properties.UUID
+func (_e *MockAgentTypeQuerier_Expecter) CountByServiceType(ctx interface{}, serviceTypeID interface{}) *MockAgentTypeQuerier_CountByServiceType_Call {
+	return &MockAgentTypeQuerier_CountByServiceType_Call{Call: _e.mock.On("CountByServiceType", ctx, serviceTypeID)}
+}
+
+func (_c *MockAgentTypeQuerier_CountByServiceType_Call) Run(run func(ctx context.Context, serviceTypeID properties.UUID)) *MockAgentTypeQuerier_CountByServiceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 properties.UUID
+		if args[1] != nil {
+			arg1 = args[1].(properties.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAgentTypeQuerier_CountByServiceType_Call) Return(n int64, err error) *MockAgentTypeQuerier_CountByServiceType_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockAgentTypeQuerier_CountByServiceType_Call) RunAndReturn(run func(ctx context.Context, serviceTypeID properties.UUID) (int64, error)) *MockAgentTypeQuerier_CountByServiceType_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/domain/service_type.go
+++ b/pkg/domain/service_type.go
@@ -218,6 +218,14 @@ func (c *serviceTypeCommander) Delete(ctx context.Context, id properties.UUID) e
 			return NewInvalidInputErrorf("cannot delete service type %s: %d dependent service(s) exist", id, serviceCount)
 		}
 
+		atCount, err := store.AgentTypeRepo().CountByServiceType(ctx, id)
+		if err != nil {
+			return fmt.Errorf("failed to count agent types for service type %s: %w", id, err)
+		}
+		if atCount > 0 {
+			return NewInvalidInputErrorf("cannot delete service type %s: %d dependent agent type(s) exist", id, atCount)
+		}
+
 		eventEntry, err := NewEvent(EventTypeServiceTypeDeleted, WithInitiatorCtx(ctx), WithServiceType(serviceType))
 		if err != nil {
 			return err

--- a/pkg/domain/service_type_test.go
+++ b/pkg/domain/service_type_test.go
@@ -1,10 +1,15 @@
 package domain
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/fulcrumproject/core/pkg/auth"
+	"github.com/fulcrumproject/core/pkg/properties"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestServiceType_TableName(t *testing.T) {
@@ -48,6 +53,69 @@ func TestServiceTypeBasics(t *testing.T) {
 			// Just test that the struct can be created
 			assert.NotNil(t, tt.serviceType)
 			assert.Equal(t, tt.serviceType.Name, tt.serviceType.Name)
+		})
+	}
+}
+
+func TestServiceTypeCommander_Delete(t *testing.T) {
+	stID := properties.UUID(uuid.New())
+
+	type stubs struct {
+		serviceCount int64
+		atCount      int64
+	}
+
+	tests := []struct {
+		name        string
+		stubs       stubs
+		wantErr     bool
+		errContains string
+	}{
+		{name: "happy path", stubs: stubs{serviceCount: 0, atCount: 0}, wantErr: false},
+		{name: "blocked by dependent services", stubs: stubs{serviceCount: 1, atCount: 0}, wantErr: true, errContains: "dependent service"},
+		{name: "blocked by dependent agent types", stubs: stubs{serviceCount: 0, atCount: 2}, wantErr: true, errContains: "dependent agent type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms := NewMockStore(t)
+			ms.EXPECT().Atomic(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, fn func(Store) error) error {
+				return fn(ms)
+			}).Maybe()
+
+			stRepo := NewMockServiceTypeRepository(t)
+			stRepo.On("Get", mock.Anything, stID).Return(&ServiceType{BaseEntity: BaseEntity{ID: stID}, Name: "st"}, nil).Maybe()
+			stRepo.On("Delete", mock.Anything, stID).Return(nil).Maybe()
+			ms.On("ServiceTypeRepo").Return(stRepo).Maybe()
+
+			serviceRepo := NewMockServiceRepository(t)
+			serviceRepo.On("CountByServiceType", mock.Anything, stID).Return(tt.stubs.serviceCount, nil).Maybe()
+			ms.On("ServiceRepo").Return(serviceRepo).Maybe()
+
+			atRepo := NewMockAgentTypeRepository(t)
+			atRepo.On("CountByServiceType", mock.Anything, stID).Return(tt.stubs.atCount, nil).Maybe()
+			ms.On("AgentTypeRepo").Return(atRepo).Maybe()
+
+			eventRepo := NewMockEventRepository(t)
+			eventRepo.On("Create", mock.Anything, mock.Anything).Return(nil).Maybe()
+			ms.On("EventRepo").Return(eventRepo).Maybe()
+
+			commander := NewServiceTypeCommander(ms, nil)
+			ctx := auth.WithIdentity(context.Background(), &auth.Identity{Role: auth.RoleAdmin, ID: properties.UUID(uuid.New())})
+
+			err := commander.Delete(ctx, stID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error to contain %q, got %v", tt.errContains, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Delete() error = %v", err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
…e and delete stale data on agent type delete for both joins (service-type, infra-type)